### PR TITLE
Fix equality for QuotaVariableDefinition

### DIFF
--- a/Nfield.Quota.Tests/QuotaVariableDefinitionTests.cs
+++ b/Nfield.Quota.Tests/QuotaVariableDefinitionTests.cs
@@ -1,0 +1,146 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Nfield.Quota.Tests
+{
+    [TestFixture]
+    public class QuotaVariableDefinitionTests
+    {
+        [Test]
+        public void Test_OperatorEquals_ReferenceEquals()
+        {
+            var variable = new QuotaVariableDefinition();
+            var variableReference = variable;
+
+            Assert.True(variable == variableReference);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ComparisonWithNull()
+        {
+            QuotaVariableDefinition variable = new QuotaVariableDefinition();
+            Assert.IsFalse(variable == null);
+            Assert.IsFalse(null == variable);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ReferenceEquals()
+        {
+            var variable = new QuotaVariableDefinition();
+            var variableReference = variable;
+            Assert.IsFalse(variable != variableReference);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ComparisonWithNull()
+        {
+            QuotaVariableDefinition variable = null;
+            Assert.IsFalse(variable != null);
+            Assert.IsFalse(null != variable);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ValuesEqual_ReturnsTrue()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            Assert.IsTrue(variable1 == variable2);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ValuesNotEqual_ReturnsFalse()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "differentVar",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            Assert.IsFalse(variable1 == variable2);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ValuesEqual_ReturnsFalse()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            Assert.IsFalse(variable1 != variable2);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ValuesNotEqual_ReturnsTrue()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "differentVar",
+                OdinVariableName = "odinVar",
+                IsMulti = true,
+                IsSelectionOptional = true,
+            };
+
+            Assert.IsTrue(variable1 != variable2);
+        }
+    }
+}

--- a/Nfield.Quota/QuotaVariableDefinition.cs
+++ b/Nfield.Quota/QuotaVariableDefinition.cs
@@ -33,7 +33,19 @@ namespace Nfield.Quota
 
         public static bool operator ==(QuotaVariableDefinition left, QuotaVariableDefinition right)
         {
-            return left?.Equals(right) ?? false;
+            // If both are null, or both are same instance, return true.
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            // If one is null, but not both, return false.
+            if (((object)left == null) || ((object)right == null))
+            {
+                return false;
+            }
+
+            return left.Equals(right);
         }
 
         public static bool operator !=(QuotaVariableDefinition left, QuotaVariableDefinition right)
@@ -54,13 +66,16 @@ namespace Nfield.Quota
 
         public bool Equals(QuotaVariableDefinition other)
         {
-            if (ReferenceEquals(this, other)) return true;
-            if (ReferenceEquals(other, null)) return false;
-
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            
             return Id == other.Id
                    && Name == other.Name
                    && OdinVariableName == other.OdinVariableName
                    && IsSelectionOptional == other.IsSelectionOptional
+                   && IsMulti == other.IsMulti
                    && Levels.ScrambledDefinitionsEquals(other.Levels);
         }
     }

--- a/Nfield.Quota/QuotaVariableDefinition.cs
+++ b/Nfield.Quota/QuotaVariableDefinition.cs
@@ -33,15 +33,13 @@ namespace Nfield.Quota
 
         public static bool operator ==(QuotaVariableDefinition left, QuotaVariableDefinition right)
         {
-            // If both are null, or both are same instance, return true.
-            if (ReferenceEquals(left, right))
+            if (ReferenceEquals(left, null))
             {
-                return true;
-            }
+                if (ReferenceEquals(right, null))
+                {
+                    return true;
+                }
 
-            // If one is null, but not both, return false.
-            if (((object)left == null) || ((object)right == null))
-            {
                 return false;
             }
 


### PR DESCRIPTION
Comparison to null would not return the correct results.

The same problem exists in the QuotaLevelDefinition class and the QuotaVariableDefinitionCollection class but those will be tackled in a separate PR