### PR TITLE
[Story] Fix equality

### DIFF
--- a/Nfield.Quota.Tests/QuotaLevelDefinitionTests.cs
+++ b/Nfield.Quota.Tests/QuotaLevelDefinitionTests.cs
@@ -1,0 +1,122 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Nfield.Quota.Tests
+{
+    [TestFixture]
+    public class QuotaLevelDefinitionTests
+    {
+        [Test]
+        public void Test_OperatorEquals_ReferenceEquals()
+        {
+            var level = new QuotaLevelDefinition();
+            var levelReference = level;
+
+            Assert.True(level == levelReference);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ComparisonWithNull()
+        {
+            var level = new QuotaLevelDefinition();
+            Assert.IsFalse(level == null);
+            Assert.IsFalse(null == level);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ReferenceEquals()
+        {
+            var level = new QuotaLevelDefinition();
+            var levelReference = level;
+            Assert.IsFalse(level != levelReference);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ComparisonWithNull()
+        {
+            QuotaLevelDefinition level = null;
+            Assert.IsFalse(level != null);
+            Assert.IsFalse(null != level);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ValuesEqual_ReturnsTrue()
+        {
+            var id = Guid.NewGuid();
+
+            var level1 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "level"
+            };
+
+            var level2 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "level"
+            };
+
+            Assert.IsTrue(level1 == level2);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ValuesNotEqual_ReturnsFalse()
+        {
+            var id = Guid.NewGuid();
+
+            var level1 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "level"
+            };
+
+            var level2 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "differentLevel"
+            };
+
+            Assert.IsFalse(level1 == level2);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ValuesEqual_ReturnsFalse()
+        {
+            var id = Guid.NewGuid();
+
+            var level1 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "level"
+            };
+
+            var level2 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "level"
+            };
+
+            Assert.IsFalse(level1 != level2);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ValuesNotEqual_ReturnsTrue()
+        {
+            var id = Guid.NewGuid();
+
+            var level1 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "level"
+            };
+
+            var level2 = new QuotaLevelDefinition
+            {
+                Id = id,
+                Name = "differentLevel"
+            };
+
+            Assert.IsTrue(level1 != level2);
+        }
+    }
+}

--- a/Nfield.Quota.Tests/QuotaVariableDefinitionCollectionTests.cs
+++ b/Nfield.Quota.Tests/QuotaVariableDefinitionCollectionTests.cs
@@ -1,0 +1,158 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Nfield.Quota.Tests
+{
+    [TestFixture]
+    public class QuotaVariableDefinitionCollectionTests
+    {
+        [Test]
+        public void Test_OperatorEquals_ReferenceEquals()
+        {
+            var variableCollection = new QuotaVariableDefinitionCollection();
+            var variableCollectionReference = variableCollection;
+
+            Assert.True(variableCollection == variableCollectionReference);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ComparisonWithNull()
+        {
+            var variableCollection = new QuotaVariableDefinitionCollection();
+            Assert.IsFalse(variableCollection == null);
+            Assert.IsFalse(null == variableCollection);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ReferenceEquals()
+        {
+            var variableCollection = new QuotaVariableDefinitionCollection();
+            var variableCollectionReference = variableCollection;
+            Assert.IsFalse(variableCollection != variableCollectionReference);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ComparisonWithNull()
+        {
+            QuotaVariableDefinitionCollection variableCollection = null;
+            Assert.IsFalse(variableCollection != null);
+            Assert.IsFalse(null != variableCollection);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_SameOrderValuesEqual_ReturnsTrue()
+        {
+            var variable = new QuotaVariableDefinition();
+
+            var variableCollection1 = new QuotaVariableDefinitionCollection();
+            variableCollection1.Add(variable);
+
+            var variableCollection2 = new QuotaVariableDefinitionCollection();
+            variableCollection2.Add(variable);
+
+            Assert.IsTrue(variableCollection1 == variableCollection2);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_DifferentOrderValuesEqual_ReturnsTrue()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar"
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "differentVar",
+                OdinVariableName = "odinVar"
+            };
+
+            var variableCollection1 = new QuotaVariableDefinitionCollection();
+            variableCollection1.Add(variable1);
+            variableCollection1.Add(variable2);
+
+            var variableCollection2 = new QuotaVariableDefinitionCollection();
+            variableCollection2.Add(variable2);
+            variableCollection2.Add(variable1);
+
+            Assert.IsTrue(variableCollection1 == variableCollection2);
+        }
+
+        [Test]
+        public void Test_OperatorEquals_ValuesNotEqual_ReturnsFalse()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar"
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "differentVar",
+                OdinVariableName = "odinVar"
+            };
+
+            var variableCollection1 = new QuotaVariableDefinitionCollection();
+            variableCollection1.Add(variable1);
+            variableCollection1.Add(variable2);
+
+            var variableCollection2 = new QuotaVariableDefinitionCollection();
+            variableCollection2.Add(variable2);
+
+            Assert.IsFalse(variableCollection1 == variableCollection2);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ValuesEqual_ReturnsFalse()
+        {
+            var variable = new QuotaVariableDefinition();
+
+            var variableCollection1 = new QuotaVariableDefinitionCollection();
+            variableCollection1.Add(variable);
+
+            var variableCollection2 = new QuotaVariableDefinitionCollection();
+            variableCollection2.Add(variable);
+
+            Assert.IsFalse(variableCollection1 != variableCollection2);
+        }
+
+        [Test]
+        public void Test_OperatorNotEquals_ValuesNotEqual_ReturnsTrue()
+        {
+            var id = Guid.NewGuid();
+
+            var variable1 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "var",
+                OdinVariableName = "odinVar"
+            };
+
+            var variable2 = new QuotaVariableDefinition
+            {
+                Id = id,
+                Name = "differentVar",
+                OdinVariableName = "odinVar"
+            };
+
+            var variableCollection1 = new QuotaVariableDefinitionCollection();
+            variableCollection1.Add(variable1);
+            variableCollection1.Add(variable2);
+
+            var variableCollection2 = new QuotaVariableDefinitionCollection();
+            variableCollection2.Add(variable2);
+
+            Assert.IsTrue(variableCollection1 != variableCollection2);
+        }
+    }
+}

--- a/Nfield.Quota/QuotaLevelDefinition.cs
+++ b/Nfield.Quota/QuotaLevelDefinition.cs
@@ -9,7 +9,7 @@ namespace Nfield.Quota
 
         public static bool operator ==(QuotaLevelDefinition left, QuotaLevelDefinition right)
         {
-            return left?.Equals(right) ?? false;
+            return left?.Equals(right) ?? ReferenceEquals(right, null);
         }
 
         public static bool operator !=(QuotaLevelDefinition left, QuotaLevelDefinition right)

--- a/Nfield.Quota/QuotaVariableDefinition.cs
+++ b/Nfield.Quota/QuotaVariableDefinition.cs
@@ -33,17 +33,7 @@ namespace Nfield.Quota
 
         public static bool operator ==(QuotaVariableDefinition left, QuotaVariableDefinition right)
         {
-            if (ReferenceEquals(left, null))
-            {
-                if (ReferenceEquals(right, null))
-                {
-                    return true;
-                }
-
-                return false;
-            }
-
-            return left.Equals(right);
+            return left?.Equals(right) ?? ReferenceEquals(right, null);
         }
 
         public static bool operator !=(QuotaVariableDefinition left, QuotaVariableDefinition right)

--- a/Nfield.Quota/QuotaVariableDefinitionCollection.cs
+++ b/Nfield.Quota/QuotaVariableDefinitionCollection.cs
@@ -15,7 +15,7 @@ namespace Nfield.Quota
 
         public static bool operator ==(QuotaVariableDefinitionCollection left, QuotaVariableDefinitionCollection right)
         {
-            return left?.Equals(right) ?? false;
+            return left?.Equals(right) ?? ReferenceEquals(right, null);
         }
 
         public static bool operator !=(QuotaVariableDefinitionCollection left, QuotaVariableDefinitionCollection right)


### PR DESCRIPTION
This fixes the problem that when you set a leveldefinition or variabledefinitioncollection to null they are not equal to null (using == or !=)