### PR TITLE
Fix integer overflow issue

### DIFF
--- a/Nfield.Quota/Helpers/FrameExtensions.cs
+++ b/Nfield.Quota/Helpers/FrameExtensions.cs
@@ -44,7 +44,7 @@ namespace Nfield.Quota.Helpers
                 // if any of the child levels had a null target, the max target will
                 // be 'infinite' (actually just the max int value). we don't want to
                 // overflow so we check for that.
-                if (levelMax == int.MaxValue)
+                if (levelMax == int.MaxValue || total == int.MaxValue)
                 {
                     return int.MaxValue;
                 }


### PR DESCRIPTION
With the previous code, if the first level had no max target, while the second did, it would try to add the second's max target to `int.MaxValue`, which would cause an integer overflow and mess up the min/max logic in the `Aggregate`s.

Now, the code never overflows so the logic makes sense again.