### PR TITLE
Swap CodeAnalysis.FxCopAnalyzers for CodeAnalysis.NetAnalyzers

### DIFF
--- a/CodeAnalysis/NipoSoftware.DefaultProjectRules.targets
+++ b/CodeAnalysis/NipoSoftware.DefaultProjectRules.targets
@@ -3,6 +3,7 @@
     <RelativePathToCodeAnalysis Condition="'$(RelativePathToCodeAnalysis)' == ''">..</RelativePathToCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <RunCodeAnalysis>false</RunCodeAnalysis><!-- disable legacy code analysis -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>$(RelativePathToCodeAnalysis)\CodeAnalysis\Standard Rules for NIPO Software.ruleset</CodeAnalysisRuleSet>

--- a/Nfield.Quota.sln
+++ b/Nfield.Quota.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{1050C460-9431-
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CA0ED88A-A281-48B5-BC9C-85399B0E3D1B}"
 	ProjectSection(SolutionItems) = preProject
+		CodeAnalysis\NipoSoftware.DefaultProjectRules.targets = CodeAnalysis\NipoSoftware.DefaultProjectRules.targets
 		CodeAnalysis\Standard rules for NIPO Software.ruleset = CodeAnalysis\Standard rules for NIPO Software.ruleset
 	EndProjectSection
 EndProject

--- a/Nfield.Quota/GlobalSuppressions.cs
+++ b/Nfield.Quota/GlobalSuppressions.cs
@@ -1,0 +1,4 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+// Please Guru of this holy code, can you tell me if I can add [assembly:CLSCompliant(true)] in the properties, or leave this supress message here.
+[assembly: SuppressMessage("Microsoft.Design", "CA1014:MarkAssembliesWithClsCompliant", Justification = "Awaiting justification from the CodeGuru...")]

--- a/Nfield.Quota/Nfield.Quota.csproj
+++ b/Nfield.Quota/Nfield.Quota.csproj
@@ -22,7 +22,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Nfield.Quota/Persistence/QuotaFrameContractResolver.cs
+++ b/Nfield.Quota/Persistence/QuotaFrameContractResolver.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Nfield.Quota.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -28,6 +29,11 @@ namespace Nfield.Quota.Persistence
         [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "We want propertyName in lowercase and we don't care about locale")]
         public void Ignore(Type type, params string[] propertyName)
         {
+            if(propertyName is null)
+            {
+                return;
+            }
+
             // start bucket if DNE
             if (!_ignores.ContainsKey(type))
             {


### PR DESCRIPTION
[AB#85340](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/85340)

The package [Microsoft.CodeAnalysis.FxCopAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers) has been deprecated in favor of [Microsoft.CodeAnalysis.NetAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers/).

`Microsoft.CodeAnalysis.NetAnalyzers` is much [more conservative](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview#enabled-rules) compared to `Microsoft.CodeAnalysis.FxCopAnalyzers`.

We therefor set the `AnalysisMode` to `AllEnabledByDefault`. (see [migration steps](https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019#migration-steps) for more information)

---

Related PRs:

- https://github.com/NIPOSoftwareBV/Nfield-Cati/pull/608
- https://github.com/NIPOSoftwareBV/nfield-source/pull/6231
- https://github.com/NIPOSoftwareBV/Nfield-Activities/pull/27
- https://github.com/NIPOSoftwareBV/project-glu-api/pull/3100
- https://github.com/NIPOSoftwareBV/nfield-permissions/pull/78
- https://github.com/NIPOSoftwareBV/nfield-tenant-signup/pull/141
- https://github.com/NIPOSoftwareBV/nfield-nativeengine/pull/111
- https://github.com/NIPOSoftwareBV/nfield-reporting-events/pull/113
- https://github.com/NIPOSoftwareBV/nfield-storage/pull/215
- https://github.com/NIPOSoftwareBV/nfield-odinparser/pull/62
- https://github.com/NIPOSoftwareBV/nfield-remote-mediator/pull/30
- https://github.com/NIPOSoftwareBV/nfield-interviewing-contracts/pull/30
- https://github.com/NIPOSoftwareBV/nfield-survey-fieldwork-package/pull/39
- https://github.com/NIPOSoftware/Nfield-SDK/pull/224
- https://github.com/NIPOSoftware/Nfield.Quota/pull/106