### PR TITLE
Pipelines (Part 2): Remove manual actions with timeouts

### DIFF
--- a/pipelines/deploy-nuget.yml
+++ b/pipelines/deploy-nuget.yml
@@ -31,6 +31,8 @@ pool:
   
 
 stages:
+
+  ####################### INTERNAL DEPLOY NFIELD ####################
  - template: AzureDevOps/SDK-and-Quota-pipelines/YmlTemplates/deploy.yml@NfieldTools
    parameters:
      pipelineDependency: QuotaBuild

--- a/pipelines/deploy-nuget.yml
+++ b/pipelines/deploy-nuget.yml
@@ -31,4 +31,18 @@ pool:
   
 
 stages:
- - template: AzureDevOps/SDK-and-Quota-pipelines/deploy-quota-nuget.yml@NfieldTools
+ - template: AzureDevOps/SDK-and-Quota-pipelines/YmlTemplates/deploy.yml@NfieldTools
+   parameters:
+     stageDependency: GetResources
+     pipelineDependency: QuotaBuild
+     nuGetFeedType: internal
+     featureName: Quota
+
+  ####################### EXTERNAL DEPLOY NUGET.ORG ####################
+ - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release') }}:
+   - template: AzureDevOps/SDK-and-Quota-pipelines/YmlTemplates/deploy.yml@NfieldTools
+     parameters:
+       stageDependency: GetResources
+       pipelineDependency: QuotaBuild
+       nuGetFeedType: external
+       featureName: Quota

--- a/pipelines/deploy-nuget.yml
+++ b/pipelines/deploy-nuget.yml
@@ -33,7 +33,6 @@ pool:
 stages:
  - template: AzureDevOps/SDK-and-Quota-pipelines/YmlTemplates/deploy.yml@NfieldTools
    parameters:
-     stageDependency: GetResources
      pipelineDependency: QuotaBuild
      nuGetFeedType: internal
      featureName: Quota
@@ -42,7 +41,6 @@ stages:
  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release') }}:
    - template: AzureDevOps/SDK-and-Quota-pipelines/YmlTemplates/deploy.yml@NfieldTools
      parameters:
-       stageDependency: GetResources
        pipelineDependency: QuotaBuild
        nuGetFeedType: external
        featureName: Quota


### PR DESCRIPTION
[AB#177932](https://dev.azure.com/niposoftware/f685c5aa-d2ad-4e41-a056-e47072508e1a/_workitems/edit/177932)

Manual actions with timeout generate fake wrong positives on failed deployments.
We should control the deployments through the Environments instead, for example, so we don't have that issue not the perception that a deploy is running while it's only waiting for approval.

Removed the first stage that is not necessary as long as we control the approvals in the deployment job

[Related](https://github.com/NIPOSoftwareBV/Nfield-Tools/pull/1397)

## Before
<img width="536" height="161" alt="image" src="https://github.com/user-attachments/assets/765a45cf-69d5-4cc0-b5a1-c3c4bb351241" />


## After

<img width="313" height="243" alt="image" src="https://github.com/user-attachments/assets/f4ac66e7-61f1-4dc4-9139-98dceca78a42" />